### PR TITLE
refactor(signal): refactor signal handling across platforms

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -68,9 +68,7 @@ func (g *Manager) handleSignals(ctx context.Context) {
 
 	signal.Notify(
 		c,
-		syscall.SIGINT,
-		syscall.SIGTERM,
-		syscall.SIGTSTP,
+		signals...,
 	)
 	defer signal.Stop(c)
 
@@ -87,8 +85,6 @@ func (g *Manager) handleSignals(ctx context.Context) {
 				g.logger.Infof("PID %d. Received SIGTERM. Shutting down...", pid)
 				g.doGracefulShutdown()
 				return
-			case syscall.SIGTSTP:
-				g.logger.Info("PID %d. Received SIGTSTP.", pid)
 			default:
 				g.logger.Infof("PID %d. Received %v.", pid, sig)
 			}

--- a/manager_test.go
+++ b/manager_test.go
@@ -3,6 +3,7 @@ package graceful
 import (
 	"context"
 	"errors"
+	"os"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -240,8 +241,12 @@ func TestWithSignalSIGINT(t *testing.T) {
 
 	go func() {
 		time.Sleep(50 * time.Millisecond)
-		if err := syscall.Kill(syscall.Getpid(), syscall.SIGINT); err != nil {
-			t.Errorf("syscall error: %v", err)
+		process, err := os.FindProcess(syscall.Getpid())
+		if err != nil {
+			t.Errorf("os.FindProcess error: %v", err)
+		}
+		if err := process.Signal(syscall.SIGINT); err != nil {
+			t.Errorf("process.Signal error: %v", err)
 		}
 	}()
 
@@ -270,8 +275,12 @@ func TestWithSignalSIGTERM(t *testing.T) {
 
 	go func() {
 		time.Sleep(50 * time.Millisecond)
-		if err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM); err != nil {
-			t.Errorf("syscall error: %v", err)
+		process, err := os.FindProcess(syscall.Getpid())
+		if err != nil {
+			t.Errorf("os.FindProcess error: %v", err)
+		}
+		if err := process.Signal(syscall.SIGTERM); err != nil {
+			t.Errorf("process.Signal error: %v", err)
 		}
 	}()
 

--- a/signals_unix.go
+++ b/signals_unix.go
@@ -1,0 +1,11 @@
+//go:build linux || bsd || darwin
+// +build linux bsd darwin
+
+package graceful
+
+import (
+	"os"
+	"syscall"
+)
+
+var signals = []os.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGTSTP}

--- a/signals_windows.go
+++ b/signals_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+// +build windows
+
+package graceful
+
+import (
+	"os"
+	"syscall"
+)
+
+var signals = []os.Signal{syscall.SIGINT, syscall.SIGTERM}


### PR DESCRIPTION
- Refactor signal handling in `manager.go` to use a slice of signals instead of individual signal constants.
- Remove handling of `SIGTSTP` signal and associated logging in `manager.go`.
- Update signal sending in tests within `manager_test.go` to use `os.FindProcess` and `process.Signal` instead of `syscall.Kill`.
- Add `os` package import in `manager_test.go`.
- Create new file `signals_unix.go` with a slice of signals for Unix-based systems including `SIGINT`, `SIGTERM`, and `SIGTSTP`.
- Create new file `signals_windows.go` with a slice of signals for Windows systems including `SIGINT` and `SIGTERM`.